### PR TITLE
Allow using a custom message for FingerPrint reason message

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This cn1lib provides basic support for fingerprint scanning on iOS/Android with 
 You can see a test application [here](https://github.com/codenameone/FingerprintScannerTest). Usage of this library is as follows:
 
 ````java
-Fingerprint.scanFingerprint(value -> {
+Fingerprint.scanFingerprint("Use your finger print to unlock AppName.", value -> {
     Log.p("Scan successfull!");
 }, (sender, err, errorCode, errorMessage) -> {
     Log.p("Scan Failed!");

--- a/native/android/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/android/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -29,7 +29,7 @@ public class InternalFingerprintImpl {
         return response[0];
     }
 
-    public void scan(String reason) {
+    public void scan() {
         AndroidNativeUtil.getActivity().runOnUiThread(new Runnable() {
             public void run() {
                 CancellationSignal cs = new CancellationSignal();

--- a/native/android/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/android/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -29,7 +29,7 @@ public class InternalFingerprintImpl {
         return response[0];
     }
 
-    public void scan() {
+    public void scan(String reason) {
         AndroidNativeUtil.getActivity().runOnUiThread(new Runnable() {
             public void run() {
                 CancellationSignal cs = new CancellationSignal();

--- a/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.h
+++ b/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.h
@@ -4,6 +4,7 @@
 }
 
 -(BOOL)isAvailable;
+-(void)scan;
 -(void)scan:(NSString *)reason;
 -(BOOL)isSupported;
 @end

--- a/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.h
+++ b/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.h
@@ -4,6 +4,6 @@
 }
 
 -(BOOL)isAvailable;
--(void)scan;
+-(void)scan:(NSString *)reason;
 -(BOOL)isSupported;
 @end

--- a/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.h
+++ b/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.h
@@ -4,7 +4,6 @@
 }
 
 -(BOOL)isAvailable;
--(void)scan;
 -(void)scan:(NSString *)reason;
 -(BOOL)isSupported;
 @end

--- a/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.m
+++ b/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.m
@@ -18,10 +18,13 @@
 }
 
 
--(void)scan{
+-(void)scan:(NSString *)reason {
+    if (reason == nil) {
+        reason = @"Authenticate for server login";
+    }
     dispatch_async(dispatch_get_main_queue(), ^{
         LAContext *context = [[LAContext alloc] init];
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:@"Authenticate for server login" reply:^(BOOL success, NSError *authenticationError){
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:reason reply:^(BOOL success, NSError *authenticationError){
             if (success) {
                 com_codename1_fingerprint_impl_InternalCallback_scanSuccess__(getThreadLocalData());
             }

--- a/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.m
+++ b/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.m
@@ -18,12 +18,10 @@
 }
 
 
--(void)scan {
-    NSString *reason = @"Authenticate for server login";
-    [self scan:reason];
-}
-
 -(void)scan:(NSString *)reason {
+    if (reason == nil) {
+        reason = @"Authenticate for server login";
+    }
     dispatch_async(dispatch_get_main_queue(), ^{
         LAContext *context = [[LAContext alloc] init];
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:reason reply:^(BOOL success, NSError *authenticationError){

--- a/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.m
+++ b/native/ios/com_codename1_fingerprint_impl_InternalFingerprintImpl.m
@@ -18,10 +18,12 @@
 }
 
 
+-(void)scan {
+    NSString *reason = @"Authenticate for server login";
+    [self scan:reason];
+}
+
 -(void)scan:(NSString *)reason {
-    if (reason == nil) {
-        reason = @"Authenticate for server login";
-    }
     dispatch_async(dispatch_get_main_queue(), ^{
         LAContext *context = [[LAContext alloc] init];
         [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:reason reply:^(BOOL success, NSError *authenticationError){

--- a/native/j2me/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/j2me/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -5,9 +5,6 @@ public class InternalFingerprintImpl {
         return false;
     }
 
-    public void scan() {
-    }
-
     public void scan(String reason) {
     }
 

--- a/native/j2me/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/j2me/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -5,7 +5,7 @@ public class InternalFingerprintImpl {
         return false;
     }
 
-    public void scan() {
+    public void scan(String reason) {
     }
 
     public boolean isSupported() {

--- a/native/j2me/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/j2me/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -5,6 +5,9 @@ public class InternalFingerprintImpl {
         return false;
     }
 
+    public void scan() {
+    }
+
     public void scan(String reason) {
     }
 

--- a/native/javase/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/javase/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -1,8 +1,12 @@
 package com.codename1.fingerprint.impl;
 
-public class InternalFingerprintImpl implements com.codename1.fingerprint.impl.InternalFingerprint{
+public class InternalFingerprintImpl implements com.codename1.fingerprint.impl.InternalFingerprint {
+
     public boolean isAvailable() {
         return false;
+    }
+
+    public void scan() {
     }
 
     public void scan(String reason) {

--- a/native/javase/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/javase/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -1,12 +1,8 @@
 package com.codename1.fingerprint.impl;
 
-public class InternalFingerprintImpl implements com.codename1.fingerprint.impl.InternalFingerprint {
-
+public class InternalFingerprintImpl implements com.codename1.fingerprint.impl.InternalFingerprint{
     public boolean isAvailable() {
         return false;
-    }
-
-    public void scan() {
     }
 
     public void scan(String reason) {

--- a/native/javase/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/javase/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -5,7 +5,7 @@ public class InternalFingerprintImpl implements com.codename1.fingerprint.impl.I
         return false;
     }
 
-    public void scan() {
+    public void scan(String reason) {
     }
 
     public boolean isSupported() {

--- a/native/rim/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/rim/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -1,12 +1,8 @@
 package com.codename1.fingerprint.impl;
 
 public class InternalFingerprintImpl {
-
     public boolean isAvailable() {
         return false;
-    }
-
-    public void scan() {
     }
 
     public void scan(String reason) {

--- a/native/rim/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/rim/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -5,7 +5,7 @@ public class InternalFingerprintImpl {
         return false;
     }
 
-    public void scan() {
+    public void scan(String reason) {
     }
 
     public boolean isSupported() {

--- a/native/rim/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
+++ b/native/rim/com/codename1/fingerprint/impl/InternalFingerprintImpl.java
@@ -1,8 +1,12 @@
 package com.codename1.fingerprint.impl;
 
 public class InternalFingerprintImpl {
+
     public boolean isAvailable() {
         return false;
+    }
+
+    public void scan() {
     }
 
     public void scan(String reason) {

--- a/native/win/com/codename1/fingerprint/impl/InternalFingerprintImpl.cs
+++ b/native/win/com/codename1/fingerprint/impl/InternalFingerprintImpl.cs
@@ -6,7 +6,7 @@ public class InternalFingerprintImpl : IInternalFingerprintImpl {
         return false;
     }
 
-    public void scan() {
+    public void scan(string reason) {
     }
 
     public bool isSupported() {

--- a/native/win/com/codename1/fingerprint/impl/InternalFingerprintImpl.cs
+++ b/native/win/com/codename1/fingerprint/impl/InternalFingerprintImpl.cs
@@ -6,6 +6,9 @@ public class InternalFingerprintImpl : IInternalFingerprintImpl {
         return false;
     }
 
+    public void scan() {
+    }
+
     public void scan(string reason) {
     }
 

--- a/native/win/com/codename1/fingerprint/impl/InternalFingerprintImpl.cs
+++ b/native/win/com/codename1/fingerprint/impl/InternalFingerprintImpl.cs
@@ -6,9 +6,6 @@ public class InternalFingerprintImpl : IInternalFingerprintImpl {
         return false;
     }
 
-    public void scan() {
-    }
-
     public void scan(string reason) {
     }
 

--- a/src/com/codename1/fingerprint/Fingerprint.java
+++ b/src/com/codename1/fingerprint/Fingerprint.java
@@ -31,7 +31,7 @@ public class Fingerprint {
     }
 
     public static void scanFingerprint(String reason, SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
-        InternalCallback.init(onSuccess, onFail);
+        InternalCallback.init(reason, onSuccess, onFail);
 
         impl.scan(reason);
     }

--- a/src/com/codename1/fingerprint/Fingerprint.java
+++ b/src/com/codename1/fingerprint/Fingerprint.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.codename1.fingerprint;
 
 import com.codename1.fingerprint.impl.InternalCallback;
@@ -30,9 +25,13 @@ public class Fingerprint {
         return impl != null && impl.isSupported() && impl.isAvailable();
     }
 
+    public static void scanFingerprint(SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
+        InternalCallback.init(onSuccess, onFail);
+        impl.scan();
+    }
+
     public static void scanFingerprint(String reason, SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
         InternalCallback.init(reason, onSuccess, onFail);
-
         impl.scan(reason);
     }
 }

--- a/src/com/codename1/fingerprint/Fingerprint.java
+++ b/src/com/codename1/fingerprint/Fingerprint.java
@@ -30,9 +30,13 @@ public class Fingerprint {
         return impl != null && impl.isSupported() && impl.isAvailable();
     }
 
+    public static void scanFingerprint(SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
+        InternalCallback.init(null, onSuccess, onFail);
+        impl.scan(null);
+    }
+
     public static void scanFingerprint(String reason, SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
         InternalCallback.init(reason, onSuccess, onFail);
-
         impl.scan(reason);
     }
 }

--- a/src/com/codename1/fingerprint/Fingerprint.java
+++ b/src/com/codename1/fingerprint/Fingerprint.java
@@ -1,3 +1,8 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
 package com.codename1.fingerprint;
 
 import com.codename1.fingerprint.impl.InternalCallback;
@@ -25,13 +30,9 @@ public class Fingerprint {
         return impl != null && impl.isSupported() && impl.isAvailable();
     }
 
-    public static void scanFingerprint(SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
-        InternalCallback.init(onSuccess, onFail);
-        impl.scan();
-    }
-
     public static void scanFingerprint(String reason, SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
         InternalCallback.init(reason, onSuccess, onFail);
+
         impl.scan(reason);
     }
 }

--- a/src/com/codename1/fingerprint/Fingerprint.java
+++ b/src/com/codename1/fingerprint/Fingerprint.java
@@ -16,21 +16,23 @@ import com.codename1.util.SuccessCallback;
  * Implements the fingerprint scanning API
  */
 public class Fingerprint {
+
     private static InternalFingerprint impl;
+
     static {
         // prevents the iOS VM optimizer from optimizing away these callbacks...
         InternalCallback.scanFail();
         InternalCallback.scanSuccess();
     }
-    
+
     public static boolean isAvailable() {
         impl = NativeLookup.create(InternalFingerprint.class);
         return impl != null && impl.isSupported() && impl.isAvailable();
     }
-    
-    public static void scanFingerprint(SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
+
+    public static void scanFingerprint(String reason, SuccessCallback<Object> onSuccess, FailureCallback<Object> onFail) {
         InternalCallback.init(onSuccess, onFail);
-        
-        impl.scan();
+
+        impl.scan(reason);
     }
 }

--- a/src/com/codename1/fingerprint/impl/InternalCallback.java
+++ b/src/com/codename1/fingerprint/impl/InternalCallback.java
@@ -27,7 +27,7 @@ public class InternalCallback {
 
         // Android doesn't include a UI for fingerprints
         if (Display.getInstance().getPlatformName().equals("and")) {
-            if ("".equals(reason) || reason == null) {
+            if (reason == null) {
                 reason = "Authenticate for server login";
             }
             d = new Dialog(new BorderLayout());

--- a/src/com/codename1/fingerprint/impl/InternalCallback.java
+++ b/src/com/codename1/fingerprint/impl/InternalCallback.java
@@ -21,10 +21,6 @@ public class InternalCallback {
     private static FailureCallback<Object> onFail;
     private static Dialog d;
 
-    public static void init(SuccessCallback<Object> o1, FailureCallback<Object> o2) {
-        init(null, o1, o2);
-    }
-
     public static void init(String reason, SuccessCallback<Object> o1, FailureCallback<Object> o2) {
         onSuccess = o1;
         onFail = o2;

--- a/src/com/codename1/fingerprint/impl/InternalCallback.java
+++ b/src/com/codename1/fingerprint/impl/InternalCallback.java
@@ -21,6 +21,10 @@ public class InternalCallback {
     private static FailureCallback<Object> onFail;
     private static Dialog d;
 
+    public static void init(SuccessCallback<Object> o1, FailureCallback<Object> o2) {
+        init(null, o1, o2);
+    }
+
     public static void init(String reason, SuccessCallback<Object> o1, FailureCallback<Object> o2) {
         onSuccess = o1;
         onFail = o2;

--- a/src/com/codename1/fingerprint/impl/InternalCallback.java
+++ b/src/com/codename1/fingerprint/impl/InternalCallback.java
@@ -1,40 +1,50 @@
 package com.codename1.fingerprint.impl;
 
+import com.codename1.components.SpanLabel;
 import com.codename1.ui.Dialog;
 import com.codename1.ui.Display;
 import com.codename1.ui.FontImage;
 import com.codename1.ui.Label;
 import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.util.FailureCallback;
 import com.codename1.util.SuccessCallback;
 
 /**
  *
- * @deprecated This is an internal implementation detail of the fingerprint scanner
+ * @deprecated This is an internal implementation detail of the fingerprint
+ * scanner
  */
 public class InternalCallback {
+
     private static SuccessCallback<Object> onSuccess;
     private static FailureCallback<Object> onFail;
     private static Dialog d;
-    public static void init (SuccessCallback<Object> o1, FailureCallback<Object> o2) {
+
+    public static void init(String reason, SuccessCallback<Object> o1, FailureCallback<Object> o2) {
         onSuccess = o1;
         onFail = o2;
 
         // Android doesn't include a UI for fingerprints
-        if(Display.getInstance().getPlatformName().equals("and")) {
+        if (Display.getInstance().getPlatformName().equals("and")) {
+            if ("".equals(reason) || reason == null) {
+                reason = "Authenticate for server login";
+            }
             d = new Dialog(new BorderLayout());
             Label icon = new Label("", "DialogBody");
+            icon.getUnselectedStyle().setFgColor(0xff5722); //Sets icon color to orange
+            SpanLabel lblReason = new SpanLabel(reason, "DialogBody");
             FontImage.setMaterialIcon(icon, FontImage.MATERIAL_FINGERPRINT, 7);
-            d.add(BorderLayout.CENTER, icon);
+            d.add(BorderLayout.CENTER, BoxLayout.encloseY(icon, lblReason));
             d.showPacked(BorderLayout.CENTER, false);
             d.setDisposeWhenPointerOutOfBounds(true);
         }
     }
-    
+
     public static void scanSuccess() {
-        if(onSuccess != null) {
+        if (onSuccess != null) {
             Display.getInstance().callSerially(() -> {
-                if(d != null) {
+                if (d != null) {
                     d.dispose();
                 }
                 onSuccess.onSucess(null);
@@ -43,9 +53,9 @@ public class InternalCallback {
     }
 
     public static void scanFail() {
-        if(onFail != null) {
+        if (onFail != null) {
             Display.getInstance().callSerially(() -> {
-                if(d != null) {
+                if (d != null) {
                     d.dispose();
                 }
                 onFail.onError(null, null, 0, null);

--- a/src/com/codename1/fingerprint/impl/InternalFingerprint.java
+++ b/src/com/codename1/fingerprint/impl/InternalFingerprint.java
@@ -1,3 +1,8 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
 package com.codename1.fingerprint.impl;
 
 import com.codename1.system.NativeInterface;
@@ -7,6 +12,5 @@ import com.codename1.system.NativeInterface;
  */
 public interface InternalFingerprint extends NativeInterface {
     public boolean isAvailable();
-    public void scan();
     public void scan(String reason);
 }

--- a/src/com/codename1/fingerprint/impl/InternalFingerprint.java
+++ b/src/com/codename1/fingerprint/impl/InternalFingerprint.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.codename1.fingerprint.impl;
 
 import com.codename1.system.NativeInterface;
@@ -12,5 +7,6 @@ import com.codename1.system.NativeInterface;
  */
 public interface InternalFingerprint extends NativeInterface {
     public boolean isAvailable();
+    public void scan();
     public void scan(String reason);
 }

--- a/src/com/codename1/fingerprint/impl/InternalFingerprint.java
+++ b/src/com/codename1/fingerprint/impl/InternalFingerprint.java
@@ -12,5 +12,5 @@ import com.codename1.system.NativeInterface;
  */
 public interface InternalFingerprint extends NativeInterface {
     public boolean isAvailable();
-    public void scan();
+    public void scan(String reason);
 }


### PR DESCRIPTION
Rather than the default message of "Authenticate for server login" which
may not be the case sometimes, developer can now add a custom message to be shown to user when prompting for fingerprint input.

Also added the same message to the Dialog that is shown for Android and
changed the FingerPrint icon color to orange.