### PR TITLE
Run AsyncResource completions on EDT in InternalCallback

### DIFF
--- a/common/src/main/java/com/codename1/fingerprint/impl/InternalCallback.java
+++ b/common/src/main/java/com/codename1/fingerprint/impl/InternalCallback.java
@@ -121,7 +121,11 @@ public class InternalCallback {
         }
         requests.remove(requestId);
         if (!req.isDone()) {
-            req.complete(value);
+            Display.getInstance().callSerially(() -> {
+                if (!req.isDone()) {
+                    req.complete(value);
+                }
+            });
         }
     }
     
@@ -132,11 +136,15 @@ public class InternalCallback {
         }
         requests.remove(requestId);
         if (!req.isDone()) {
-            if ("__CANCELLED__".equals(message)) {
-                req.cancel(true);
-            } else {
-                req.error(new RuntimeException(message));
-            }
+            Display.getInstance().callSerially(() -> {
+                if (!req.isDone()) {
+                    if ("__CANCELLED__".equals(message)) {
+                        req.cancel(true);
+                    } else {
+                        req.error(new RuntimeException(message));
+                    }
+                }
+            });
         }
     }
     
@@ -147,11 +155,15 @@ public class InternalCallback {
         }
         requests.remove(requestId);
         if (!req.isDone()) {
-            if ("__CANCELLED__".equals(message)) {
-                req.cancel(true);
-            } else {
-                req.error(new KeyRevokedException(message));
-            }
+            Display.getInstance().callSerially(() -> {
+                if (!req.isDone()) {
+                    if ("__CANCELLED__".equals(message)) {
+                        req.cancel(true);
+                    } else {
+                        req.error(new KeyRevokedException(message));
+                    }
+                }
+            });
         } 
     }
     
@@ -162,7 +174,11 @@ public class InternalCallback {
         }
         requests.remove(requestId);
         if (!req.isDone()) {
-            req.complete(success);
+            Display.getInstance().callSerially(() -> {
+                if (!req.isDone()) {
+                    req.complete(success);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure that `AsyncResource` completion, error and cancel handlers are executed on the UI thread to avoid threading issues.
- Prevent race conditions where a request may be completed/cancelled multiple times by double-checking `isDone`. 
- Improve stability of fingerprint/back-end callbacks that interact with UI or UI-tied state.

### Description

- Wrap `req.complete`, `req.error`, and `req.cancel` calls in `Display.getInstance().callSerially(...)` in `InternalCallback` so they run on the EDT. 
- Retain an outer `!req.isDone()` guard and add an inner `!req.isDone()` check inside the runnable to avoid duplicate terminal actions. 
- Apply the change to `requestSuccess`, `requestError`, `requestKeyRevokedError`, and `requestComplete` methods.

### Testing

- Ran the project's automated test suite and build, and the tests completed successfully. 
- Verified that the modified callback paths execute without throwing threading-related exceptions in automated runs. 
- No automated tests failed as a result of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac2d6c578833198881ae1460f0f02)